### PR TITLE
Support installing in non-root mode

### DIFF
--- a/script/install_difftastic.sh
+++ b/script/install_difftastic.sh
@@ -1,5 +1,6 @@
-# https://github.com/Wilfred/difftastic
+#!/bin/bash
 
+# https://github.com/Wilfred/difftastic
 if command -v difft &> /dev/null
 then
   echo "Difftastic is already installed."
@@ -8,6 +9,7 @@ else
   TEMP_DIR="/tmp"
   DIFTASTIC_VERSION="0.60.0"
   DIFTASTIC_TAR="difft-x86_64-unknown-linux-gnu.tar.gz"
+  bin_dir=$1
 
   # Install Difftastic
   FILE_URL="https://github.com/Wilfred/difftastic/releases/download/$DIFTASTIC_VERSION/$DIFTASTIC_TAR"
@@ -18,7 +20,7 @@ else
   tar -xzf "$TEMP_DIR/$DIFTASTIC_TAR" -C "$TEMP_DIR"
 
   echo "Moving Difftastic to /usr/local/bin..."
-  sudo mv "$TEMP_DIR/difft" /usr/local/bin/
+  mv "$TEMP_DIR/difft" "$bin_dir"
   
   echo "Cleaning up temporary files..."
   rm "$TEMP_DIR/$DIFTASTIC_TAR"


### PR DESCRIPTION
- Added logic to determine the appropriate bin directory based on user privileges.
- Ensured the bin directory exists for non-root users.
- Updated PATH in ~/.bashrc if necessary.
- Added installation steps for Starship, rustup, fzf, and difftastic.